### PR TITLE
Allow zero in precision and format_precision

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -145,11 +145,11 @@ class Config
                 $currency['symbol'] = $currency['code'];
             }
 
-            if (empty($currency['precision'])) {
+            if ('' === trim($currency['precision'])) {
                 $currency['precision'] = 2;
             }
 
-            if (empty($currency['format_precision'])) {
+            if ('' === trim($currency['format_precision'])) {
                 $currency['format_precision'] = $currency['precision'];
             }
 


### PR DESCRIPTION
Use of empty() in the Model\Config::getCurrencies() method prevents having zero as the precision, which is really useful for a "reward points" type of currency. This change allows zero but still uses default values if the value is a blank string or false or null.