### PR TITLE
Fix array_merge fatal error in Magento 2.3.1

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -81,7 +81,7 @@ class Config
     public function getCurrency($code = null)
     {
         $currency = $this->_getCurrency($code);
-        return array_merge($currency, self::$override);
+        return $currency ? array_merge($currency, self::$override) : $currency;
     }
 
     public function _getCurrency($code = null)


### PR DESCRIPTION
(Magento 2.3.1, PHP 7.2, default mode, PHP errors not hidden). On a site which is not using custom currency, any time a price is accessed, Model\Config::_getCurrency() returns false, and so array_merge fails with 'Argument #1 is not an array'. All the calls to this allow for a false return value, and this fix appears to work for custom and non custom currency.