### PR TITLE
GJDIB-1697 fix the error when the coupon code is applied in M2.4.3-p1

### DIFF
--- a/Plugin/PriceCurrencyInterfacePlugin.php
+++ b/Plugin/PriceCurrencyInterfacePlugin.php
@@ -10,7 +10,7 @@ class PriceCurrencyInterfacePlugin
 
     public function beforeRoundPrice(\Magento\Framework\Pricing\PriceCurrencyInterface $subject,
         $price,
-        $precision
+        $precision = 2
     ) {
         $currency = $this->config->getCurrency();
         

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ecommpro/module-custom-currency",
     "description": "Custom Currency for Magento 2",
     "type": "magento2-module",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "license": "MIT",
     "authors": [
         {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="EcommPro_CustomCurrency" setup_version="1.1.2" version="1.1.3">
+    <module name="EcommPro_CustomCurrency" setup_version="1.1.2" version="1.1.4">
         <sequence>
             <module name="Magento_Catalog" />
             <module name="Magento_Checkout" />


### PR DESCRIPTION
Magento 2.4.3-p1 has changed some codes in Magento/SalesRule/Model/Rule/Action/Discount/CartFixed.php.
For example, roundPrice function is being called with one argument in line 148. It is causing error in Plugin/PriceCurrencyInterfacePlugin.php : beforeRoundPrice() because it needs two arguments. So you need to set the default value for $precision.