### PR TITLE
GJDIB-1894 fix a fatal error with trim() on PHP 8.1

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -145,11 +145,11 @@ class Config
                 $currency['symbol'] = $currency['code'];
             }
 
-            if ('' === trim($currency['precision'])) {
+            if ('' === trim($currency['precision'] ?? '')) {
                 $currency['precision'] = 2;
             }
 
-            if ('' === trim($currency['format_precision'])) {
+            if ('' === trim($currency['format_precision'] ?? '')) {
                 $currency['format_precision'] = $currency['precision'];
             }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ecommpro/module-custom-currency",
     "description": "Custom Currency for Magento 2",
     "type": "magento2-module",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "license": "MIT",
     "authors": [
         {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="EcommPro_CustomCurrency" setup_version="1.1.2" version="1.1.4">
+    <module name="EcommPro_CustomCurrency" setup_version="1.1.2" version="1.1.5">
         <sequence>
             <module name="Magento_Catalog" />
             <module name="Magento_Checkout" />


### PR DESCRIPTION
Hi, we found a fatal error in PHP 8.1 (Magento 2.4.5) in case the parameter of trim() is null. It's because the null value feature for trim() function was deprecated in PHP 8.1. Could you please merge this fix into your repo?