### PR TITLE
GJDIB-2127 fix cart and checkout js error with price-utils.js in Mage…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ecommpro/module-custom-currency",
     "description": "Custom Currency for Magento 2",
     "type": "magento2-module",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "license": "MIT",
     "authors": [
         {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="EcommPro_CustomCurrency" setup_version="1.1.2" version="1.1.5">
+    <module name="EcommPro_CustomCurrency" setup_version="1.1.2" version="1.1.6">
         <sequence>
             <module name="Magento_Catalog" />
             <module name="Magento_Checkout" />

--- a/view/base/web/js/price-utils.js
+++ b/view/base/web/js/price-utils.js
@@ -22,7 +22,35 @@ define([
      * @return {String}
      */
     function stringPad(string, times) {
-        return (new Array(times + 1)).join(string);
+        return new Array(times + 1).join(string);
+    }
+
+    /**
+     * Format the price with the compliance to the specified locale
+     *
+     * @param {Number} amount
+     * @param {Object} format
+     * @param  {Boolean} isShowSign
+     */
+    function formatPriceLocale(amount, format, isShowSign)
+    {
+        var s = '',
+            precision, pattern, locale, r;
+
+        format = _.extend(globalPriceFormat, format);
+        precision = isNaN(format.requiredPrecision = Math.abs(format.requiredPrecision)) ? 2 : format.requiredPrecision;
+        pattern = format.pattern || '%s';
+        locale = window.LOCALE || 'en-US';
+        if (isShowSign === undefined || isShowSign === true) {
+            s = amount < 0 ? '-' : isShowSign ? '+' : '';
+        } else if (isShowSign === false) {
+            s = '';
+        }
+        pattern = pattern.indexOf('{sign}') < 0 ? s + pattern : pattern.replace('{sign}', s);
+        amount = Number(Math.round(Math.abs(+amount || 0) + 'e+' + precision) + ('e-' + precision));
+        r = amount.toLocaleString(locale, {minimumFractionDigits: precision});
+
+        return pattern.replace('%s', r).replace(/^\s\s*/, '').replace(/\s\s*$/, '');
     }
 
     /**
@@ -31,6 +59,7 @@ define([
      * @param  {Object}  format
      * @param  {Boolean} isShowSign
      * @return {String}              Formatted value
+     * @deprecated
      */
     function formatPrice(amount, format, isShowSign) {
         var s = '',
@@ -55,7 +84,7 @@ define([
         pattern = pattern.indexOf('{sign}') < 0 ? s + pattern : pattern.replace('{sign}', s);
 
         // we're avoiding the usage of to fixed, and using round instead with the e representation to address
-        // numbers like 1.005 = 1.01. Using ToFixed to only provide trailig zeroes in case we have a whole number
+        // numbers like 1.005 = 1.01. Using ToFixed to only provide trailing zeroes in case we have a whole number
         i = parseInt(
                 amount = Number(Math.round(Math.abs(+amount || 0) + 'e+' + precision) + ('e-' + precision)),
                 10
@@ -114,6 +143,7 @@ define([
     }
 
     return {
+        formatPriceLocale: formatPriceLocale,
         formatPrice: formatPrice,
         deepClone: objectDeepClone,
         strPad: stringPad,


### PR DESCRIPTION
Hi, we found price-utils.js had js errors on the cart and checkout page in Magento 2.4.5. It's because Magento 2.4.5 added a new function formatPriceLocale() to the js file. So I have fixed the error. It still works on Magento 2.4.5 as well as the old versions.
Could you please merge this into your repo asap? Thanks!