### PR TITLE
Add try/catch for db connection before db exists

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -68,14 +68,18 @@ class Config
             return $this->cache['allowed'];
         }
 
-        $connection = $this->resourceConnection->getConnection();
-        $tableName = $this->resourceConnection->getTableName('ecommpro_currency_entity');
-
-        if (!$connection->isTableExists($tableName)) {
+        try {
+            $connection = $this->resourceConnection->getConnection();
+            $tableName = $this->resourceConnection->getTableName('ecommpro_currency_entity');
+    
+            if (!$connection->isTableExists($tableName)) {
+                return [];
+            }
+    
+            return $this->cache['allowed'] = $connection->fetchCol("SELECT code FROM $tableName");
+        } catch(\Exception $e) {
             return [];
         }
-
-        return $this->cache['allowed'] = $connection->fetchCol("SELECT code FROM $tableName");
     }
 
     public function getCurrency($code = null)


### PR DESCRIPTION
The `getAllowedCurrencies()` function creates a db connection within the initialization process. This causes builds to fail in Adobe Cloud due to the fact that it runs `bin/magento module:enable` _before the database is available_. The try/catch allows it to fail gracefully and finish the deploy.